### PR TITLE
Update release to 0.1.0

### DIFF
--- a/org.olivevideoeditor.Olive.yaml
+++ b/org.olivevideoeditor.Olive.yaml
@@ -69,6 +69,24 @@ modules:
         url: https://www.ffmpeg.org/releases/ffmpeg-4.1.3.tar.xz
         sha256: 0c3020452880581a8face91595b239198078645e7d7184273b8bcc7758beb63d
 
+  - name: opencolorio
+    buildsystem: cmake
+    builddir: true
+    build-options:
+      cxxflags: "-Wno-error=deprecated-declarations"
+    config-opts:
+    - "-DOCIO_BUILD_PYTHON:BOOL=OFF"
+    - "-DOCIO_BUILD_APPS:BOOL=OFF"
+    - "-DOCIO_BUILD_TESTS:BOOL=OFF"
+    - "-DOCIO_BUILD_GPU_TESTS:BOOL=OFF"
+    - "-DOCIO_BUILD_NUKE:BOOL=OFF"
+    - "-DOCIO_BUILD_DOCS:BOOL=OFF"
+    - "-DPYTHON=/usr/bin/python3.5"
+    sources:
+  - type: archive
+      url: https://github.com/imageworks/OpenColorIO/archive/v1.1.1.tar.gz
+      sha256: c9b5b9def907e1dafb29e37336b702fff22cc6306d445a13b1621b8a754c14c8
+  
   - name: olive
     buildsystem: cmake-ninja
     builddir: true
@@ -77,4 +95,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/olive-editor/olive.git
-        commit: 9a13776b2c008a17a738cb9ea216aaa70cd637c1
+        branch: master

--- a/org.olivevideoeditor.Olive.yaml
+++ b/org.olivevideoeditor.Olive.yaml
@@ -77,4 +77,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/olive-editor/olive.git
-        commit: 8cef5ce94d01063fc497fa44894e3253ed6a7413
+        commit: 9a13776b2c008a17a738cb9ea216aaa70cd637c1

--- a/org.olivevideoeditor.Olive.yaml
+++ b/org.olivevideoeditor.Olive.yaml
@@ -95,4 +95,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/olive-editor/olive.git
-        branch: master
+        commit: 1e3cf5337c51f62ef894e375c961dc6631c6a26b
+        tag: 0.1.0

--- a/org.olivevideoeditor.Olive.yaml
+++ b/org.olivevideoeditor.Olive.yaml
@@ -84,9 +84,9 @@ modules:
     - "-DPYTHON=/usr/bin/python3.5"
     sources:
       - type: archive
-      url: https://github.com/imageworks/OpenColorIO/archive/v1.1.1.tar.gz
-      sha256: c9b5b9def907e1dafb29e37336b702fff22cc6306d445a13b1621b8a754c14c8
-  
+        url: https://github.com/imageworks/OpenColorIO/archive/v1.1.1.tar.gz
+        sha256: c9b5b9def907e1dafb29e37336b702fff22cc6306d445a13b1621b8a754c14c8
+    
   - name: olive
     buildsystem: cmake-ninja
     builddir: true

--- a/org.olivevideoeditor.Olive.yaml
+++ b/org.olivevideoeditor.Olive.yaml
@@ -83,7 +83,7 @@ modules:
     - "-DOCIO_BUILD_DOCS:BOOL=OFF"
     - "-DPYTHON=/usr/bin/python3.5"
     sources:
-  - type: archive
+      - type: archive
       url: https://github.com/imageworks/OpenColorIO/archive/v1.1.1.tar.gz
       sha256: c9b5b9def907e1dafb29e37336b702fff22cc6306d445a13b1621b8a754c14c8
   


### PR DESCRIPTION
Closes https://github.com/flathub/org.olivevideoeditor.Olive/issues/4
Or can we update to continuous, till they provide more stable releases?